### PR TITLE
[FIX] Tailwind 색상 정의 추가

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
             colors: {
                 primary: {
                     cecom_blue: '#0648A6FF',
+                    cecom_blue_light: '#0029BB2E',
                     lightgray30: '#D9D9D955',
                     lightgray50: '#D9D9D980',
                     lightgray100: '#D9D9D9FF',


### PR DESCRIPTION
## Summary
누락된 Tailwind 색상을 추가로 정의하였습니다.

## Description
- 누락되었던 색상을 Tailwind Config에 추가로 정의하였습니다.
- 색상값은 `#0029BB2E`이며, `cecom_blue_light` 키워드로 접근 가능합니다.