### PR TITLE
[DEV] BE 기본 API 라우팅 구성

### DIFF
--- a/src/app/api/activities/getActivitiesData/[id]/route.ts
+++ b/src/app/api/activities/getActivitiesData/[id]/route.ts
@@ -1,0 +1,12 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+
+export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: `Activities Data API / ID is ${params.id}`,
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
+}

--- a/src/app/api/activities/getActivitiesList/route.ts
+++ b/src/app/api/activities/getActivitiesList/route.ts
@@ -1,0 +1,12 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Activities List API",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
+}

--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -1,0 +1,12 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Members List API",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
+}

--- a/src/app/api/things/getThingsList/route.ts
+++ b/src/app/api/things/getThingsList/route.ts
@@ -1,0 +1,12 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Things List API",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
+}


### PR DESCRIPTION
## Summary
Back-End에 구현할 기본 API 라우팅을 구성하였습니다.

## Description
- Activities / Members / Things 각각의 API에서 활용할 라우팅을 구성하였습니다.
- 각 API의 엔트리포인트는 다음과 같습니다.

|Activities|Members|Things|
|----------|-------|------|
|/api/activities|/api/members|/api/things|

- Activities API에서는 `/getActivitiesList`와 `/getActivitiesData/[id]` 두개의 API 함수를 제공하며, 각각 전체 Activities 리스트를 반환하는 기능과 특정 Activity의 상세 데이터를 반환하는 기능을 담당합니다.
- Members 및 Things API에서는 각각 `/getMembersList`와 `/getThingsList` API 함수를 제공하며, 각 데이터 리스트를 반환하는 기능을 담당합니다.
- 모든 API 함수는 HTTP Get 형식으로 구성하였습니다. 