### PR TITLE
[DEV] BE Members API 구현

### DIFF
--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -5,7 +5,7 @@ import {getAdminList} from "@/utils/FirebaseUtil";
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
-        RESULT_MSG: "Members List API",
+        RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
 

--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -9,7 +9,14 @@ export async function GET(_: NextRequest) {
         RESULT_DATA: undefined
     }
 
-    apiResult.RESULT_DATA = await getAdminList();
+    const adminList = await getAdminList();
+    if(adminList === undefined || adminList.length == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return apiResult;
+    }
 
+    apiResult.RESULT_DATA = adminList;
     return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -14,9 +14,9 @@ export async function GET(_: NextRequest) {
         apiResult.RESULT_CODE = 100;
         apiResult.RESULT_MSG = "An Error Occurred";
         apiResult.RESULT_DATA = undefined;
-        return apiResult;
+        return NextResponse.json(apiResult, { status: 200 });
     }
 
     apiResult.RESULT_DATA = adminList;
-    return NextResponse.json(apiResult, { status: 200 })
+    return NextResponse.json(apiResult, { status: 200 });
 }

--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -1,5 +1,6 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT} from "@/utils/Interfaces";
+import {getAdminList} from "@/utils/FirebaseUtil";
 
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
@@ -7,6 +8,8 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Members List API",
         RESULT_DATA: undefined
     }
+
+    apiResult.RESULT_DATA = await getAdminList();
 
     return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/utils/DummyData.ts
+++ b/src/utils/DummyData.ts
@@ -57,26 +57,39 @@ export const ActivityContentData: ActivityContent = {
 }
 
 /**
+ * Member 관련 더미데이터
+ */
+export const MemberData: Member = {
+    comment: "집가고싶다",
+    department: "소프트웨어학부 19학번",
+    github: "yymin1022",
+    id: "useful_min",
+    instagram: "useful_min",
+    name: "유용민",
+    project: []
+}
+
+/**
  * Admin 관련 더미데이터
  */
 
 const Admin2023_1: AdminItem = {
-    member: "shiiinnnnsh",
+    member: MemberData,
     role: "회장"
 }
 
 const Admin2023_2: AdminItem = {
-    member: "useful_min",
+    member: MemberData,
     role: "부회장"
 }
 
 const Admin2024_1: AdminItem = {
-    member: "yuni_sang",
+    member: MemberData,
     role: "회장"
 }
 
 const Admin2024_2: AdminItem = {
-    member: "vini_u",
+    member: MemberData,
     role: "부회장"
 }
 
@@ -90,19 +103,6 @@ export const Admin2023: Admin = {
 export const Admin2024: Admin = {
     list: [Admin2024_1, Admin2024_2, Admin2024_1, Admin2024_2],
     year: 2023
-}
-
-/**
- * Member 관련 더미데이터
- */
-export const MemberData: Member = {
-    comment: "집가고싶다",
-    department: "소프트웨어학부 19학번",
-    github: "yymin1022",
-    id: "useful_min",
-    instagram: "useful_min",
-    name: "유용민",
-    project: []
 }
 
 /**

--- a/src/utils/DummyData.ts
+++ b/src/utils/DummyData.ts
@@ -93,17 +93,18 @@ const Admin2024_2: AdminItem = {
     role: "부회장"
 }
 
-// 2023 운영진 더미데이터
-export const Admin2023: Admin = {
+const Admin2023: Admin = {
     list: [Admin2023_1, Admin2023_2, Admin2023_1, Admin2023_2],
     year: 2023
 }
 
-// 2024 운영진 더미데이터
-export const Admin2024: Admin = {
+const Admin2024: Admin = {
     list: [Admin2024_1, Admin2024_2, Admin2024_1, Admin2024_2],
     year: 2023
 }
+
+// 운영진 더미데이터
+export const AdminList: Array<Admin> = [Admin2024, Admin2023];
 
 /**
  * Thing 관련 더미데이터

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -14,7 +14,7 @@ const firebaseConfig = {
     appId: process.env.FB_APP_ID
 };
 
-export const initFirebase = () => {
+const initFirebase = () => {
     if(firebaseApp == null || firestoreDB == null){
         firebaseApp = initializeApp(firebaseConfig);
         firestoreDB = getFirestore(firebaseApp);
@@ -36,6 +36,8 @@ const getMemberData = async (memberID: string)  => {
 }
 
 export const getAdminList = async (year: number) => {
+    initFirebase();
+
     const adminDoc = await getDoc(doc(firestoreDB!, "Admin", year.toString()));
     const adminList: Array<AdminItem> = [];
     for (const doc of adminDoc.get("list")){

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -1,9 +1,10 @@
 import {FirebaseApp, initializeApp} from "@firebase/app";
-import {Firestore, getFirestore} from "@firebase/firestore";
+import {doc, Firestore, getDoc, getFirestore} from "@firebase/firestore";
 import dotenv from "dotenv";
+import {AdminItem, Member} from "@/utils/Interfaces";
 
-let firebaseApp: FirebaseApp
-let firestoreDB: Firestore
+let firebaseApp: FirebaseApp | null = null;
+let firestoreDB: Firestore | null = null;
 
 dotenv.config();
 const firebaseConfig = {
@@ -14,6 +15,34 @@ const firebaseConfig = {
 };
 
 export const initFirebase = () => {
-    firebaseApp = initializeApp(firebaseConfig);
-    firestoreDB = getFirestore(firebaseApp);
+    if(firebaseApp == null || firestoreDB == null){
+        firebaseApp = initializeApp(firebaseConfig);
+        firestoreDB = getFirestore(firebaseApp);
+    }
+}
+
+const getMemberData = async (memberID: string)  => {
+    const memberDoc = await getDoc(doc(firestoreDB!, "Members", memberID));
+    const memberData: Member = {
+        comment: memberDoc.get("comment"),
+        department: memberDoc.get("department"),
+        github: memberDoc.get("github"),
+        id: memberDoc.id,
+        instagram: memberDoc.get("instagram"),
+        name: memberDoc.get("name"),
+        project: memberDoc.get("project")
+    };
+    return memberData;
+}
+
+export const getAdminList = async (year: number) => {
+    const adminDoc = await getDoc(doc(firestoreDB!, "Admin", year.toString()));
+    const adminList: Array<AdminItem> = [];
+    for (const doc of adminDoc.get("list")){
+        adminList.push({
+            member: await getMemberData(doc.member),
+            role: doc.role
+        });
+    }
+    return adminList;
 }

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -48,7 +48,7 @@ export interface Admin {
 }
 
 export interface AdminItem {
-    member: string
+    member: Member
     role: string
 }
 

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: Activity | ActivityContent | Admin | Member | Photo | Thing | undefined
+    RESULT_DATA: Activity | ActivityContent | Array<Admin> | Member | Photo | Thing | undefined
 }
 
 export interface Activity {


### PR DESCRIPTION
## Summary
Back-End의 Members 관련 API를 구현하였습니다.

## Description
- Members 관련 API를 구성하였습니다.
- 각 연도별 Admin에 해당하는 Members Item을 받아와, 데이터로 구성하였습니다.
- 기존에 Interface 및 Dummy Data에 구성했던 것을 개선하여, 전체 연도 Admin 정보를 받아와 List로 구성합니다.
- 개선한 List 형식을 기존에 구현했던 Interface 및 DummyData에도 반영해두었습니다.
- 해당 API에 접근해 데이터를 받아오기 위한 Entry Point는 다음과 같으며, Axios를 이용한 요청 시 상대경로로 요청하시면 됩니다.
`/api/members/getMembersList`

- API 반환 형식은 다음과 같습니다. Interface 내에 `API_RESULT`로 정의되어있으며, 앞으로 추가로 개발될 모든 API에 동일하게 적용되는 형식입니다.

```
{
  RESULT_CODE: 200,
  RESULT_MSG: "Success",
  RESULT_DATA: DATA_OBJECT
}
```
RESULT_CODE는 `number` 형식으로, 정상 반환인 경우에는 200이, 그 외의 경우에는 200이 아닌 다른 값이 지정됩니다.
RESULT_MSG는 `string` 형식으로, 정상 반환인 경우에는 "Success"가, 그 외의 경우에는 해당하는 값이 지정됩니다.
RESULT_DATA는 해당 API의 실질적인 데이터 내용이 담기는 Entry입니다.