### PR TITLE
[FIX] Filesystem 접근불가 이슈 해결

### DIFF
--- a/src/app/api/_utils/FileUtil.ts
+++ b/src/app/api/_utils/FileUtil.ts
@@ -1,0 +1,13 @@
+import buffer from "buffer";
+import fs from "fs";
+
+export const getProjectThumbnail = (projectID: string) => {
+    const fileFullDir = `${process.env.FILE_DIR}/project/${projectID}/thumb.png`;
+    let fileBuffer: buffer.Buffer | undefined;
+    try {
+        fileBuffer = fs.readFileSync(fileFullDir);
+        return Buffer.from(fileBuffer!).toString("base64");
+    }catch(e){
+        return undefined;
+    }
+}

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -5,6 +5,7 @@ import {Activity, ActivityItem, Admin, AdminItem, Member} from "@/utils/Interfac
 import { getDocs } from "firebase/firestore";
 import * as fs from "fs";
 import * as buffer from "buffer";
+import {getProjectThumbnail} from "@/app/api/_utils/FileUtil";
 
 let firebaseApp: FirebaseApp | null = null;
 let firestoreDB: Firestore | null = null;
@@ -21,17 +22,6 @@ const initFirebase = () => {
     if(firebaseApp == null || firestoreDB == null){
         firebaseApp = initializeApp(firebaseConfig);
         firestoreDB = getFirestore(firebaseApp);
-    }
-}
-
-const getProjectThumbnail = (projectID: string) => {
-    const fileFullDir = `${process.env.FILE_DIR}/project/${projectID}/thumb.png`;
-    let fileBuffer: buffer.Buffer | undefined;
-    try {
-        fileBuffer = fs.readFileSync(fileFullDir);
-        return Buffer.from(fileBuffer!).toString("base64");
-    }catch(e){
-        return undefined;
     }
 }
 


### PR DESCRIPTION
## Summary
API에서 Filesystem에 접근하지 못하는 이슈를 해결하였습니다.

## Description
- 기존의 `FirebaseUtil` 내에서 Client-Render로 인해 서버측 로컬 Filesystem에 접근하지 못하는 이슈를 해결하였습니다.
- API 내에 `FileUtil`을 새로 구성하여, 이를 통해 Server-Runtime으로 Filesystem에 접근하도록 변경하였습니다.
- 해당 API 내 Util의 경우, 디렉토리 이름을 `_utils`로 하여 별도의 요청 Endpoint가 생성되지 않도록 처리하였습니다.