### PR TITLE
[Fix] activity card 뒷면 멤버이름 구분자 추가 

### DIFF
--- a/src/app/activities/_components/ActivityCardBack.tsx
+++ b/src/app/activities/_components/ActivityCardBack.tsx
@@ -8,7 +8,7 @@ const ActivityCardBack = ({content, member, mentor, tag, thumbnail, title, id}: 
             <div className="flex flex-row items-center mt-[10px]">
                 <div className="text-[15px] font-gmarket-m">{mentor}</div>
                 <div className="mx-[10px] font-gmarket-m">|</div>
-                <div className="text-[13px] font-gmarket-l"> {member}</div>
+                <div className="text-[13px] font-gmarket-l"> {members}</div>
             </div>
             <div className="text-[12px] mt-[10px] truncate text-pretty ">{content}</div>
             <div></div>


### PR DESCRIPTION
## Summary
activity card 뒷면 멤버이름 구분자 추가 

## Description
- 멤버 이름에 구분자 넣은 변수를 넣었어야했는데, 실수로 잘못넣음 
- member-> members로 변경함 