### PR TITLE
[DEV / FIX] Desktop Footer 변경사항 반영 및 Mobile Footer 구현

### DIFF
--- a/src/app/_components/Footer/Footer.tsx
+++ b/src/app/_components/Footer/Footer.tsx
@@ -1,4 +1,3 @@
-import NavBarDesktop from "@/app/_components/NavBar/NavBarDesktop";
 import FooterDesktop from "@/app/_components/Footer/FooterDesktop";
 
 export const Footer = () => {

--- a/src/app/_components/Footer/Footer.tsx
+++ b/src/app/_components/Footer/Footer.tsx
@@ -1,9 +1,15 @@
 import FooterDesktop from "@/app/_components/Footer/FooterDesktop";
+import FooterMobile from "@/app/_components/Footer/FooterMobile";
 
 export const Footer = () => {
     return (
         <div className="w-full flex z-20 bottom-0">
-            <FooterDesktop/>
+            <div className="w-0 invisible lg:w-full lg:visible">
+                <FooterDesktop />
+            </div>
+            <div className="w-full visible lg:w-0 lg:invisible">
+                <FooterMobile />
+            </div>
         </div>
     )
 }

--- a/src/app/_components/Footer/FooterDesktop.tsx
+++ b/src/app/_components/Footer/FooterDesktop.tsx
@@ -1,13 +1,17 @@
 
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faGithub, faInstagram} from "@fortawesome/free-brands-svg-icons";
+import Link from "next/link";
 const FooterDesktop = () => {
     return (
         <div className="w-full flex flex-col justify-center items-center h-[300px] mt-[100px]">
             <div className="flex flex-row justify-center mb-[30px]">
-
-                <FontAwesomeIcon icon={faInstagram} size="2x" className="mr-[20px]" />
-                <FontAwesomeIcon icon={faGithub} size="2x" className="mr-[20px]" />
+                <Link href={"https://instagram.com/cecom_cau"}>
+                    <FontAwesomeIcon icon={faInstagram} size="2x" className="mr-[20px]" />
+                </Link>
+                <Link href={"https://github.com/CECOM-CAU"}>
+                    <FontAwesomeIcon icon={faGithub} size="2x" className="mr-[20px]" />
+                </Link>
             </div>
             <div className="flex flex-row items-end">
                 <div className="font-gmarket-b text-[20px]">Contact</div><div className="font-gmarket-m text-[20px] ml-[10px]">cecom.cau@gmail.com</div>

--- a/src/app/_components/Footer/FooterDesktop.tsx
+++ b/src/app/_components/Footer/FooterDesktop.tsx
@@ -14,7 +14,7 @@ const FooterDesktop = () => {
             </div>
             <div className="border-[1px] border-[#000000] w-[200px] my-[20px]"></div>
             <div className="text-[15px] my-[10px]">
-                Designed by 서유빈 Developed by 유용민 임수현 정세린
+                Designed by Yubin Seo Developed by Yongmin Yoo, Sooghyun Lim, Serin Jeong
             </div>
             <div className="text-[15px] mb-[10px]">
                 &#169; 2024 CECOM ALL RIGHT RESERVED.

--- a/src/app/_components/Footer/FooterDesktop.tsx
+++ b/src/app/_components/Footer/FooterDesktop.tsx
@@ -18,7 +18,7 @@ const FooterDesktop = () => {
             </div>
             <div className="border-[1px] border-[#000000] w-[200px] my-[20px]"></div>
             <div className="text-[15px] my-[10px]">
-                Designed by Yubin Seo Developed by Yongmin Yoo, Sooghyun Lim, Serin Jeong
+                Designed by Yubin Seo / Developed by Yongmin Yoo, Sooghyun Lim, Serin Jeong
             </div>
             <div className="text-[15px] mb-[10px]">
                 &#169; 2024 CECOM ALL RIGHT RESERVED.

--- a/src/app/_components/Footer/FooterMobile.tsx
+++ b/src/app/_components/Footer/FooterMobile.tsx
@@ -1,0 +1,30 @@
+
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faGithub, faInstagram} from "@fortawesome/free-brands-svg-icons";
+import Link from "next/link";
+const FooterMobile = () => {
+    return (
+        <div className="w-full flex flex-col justify-center items-center h-[300px] mt-[100px]">
+            <div className="flex flex-row justify-center mb-[30px]">
+                <Link href={"https://instagram.com/cecom_cau"}>
+                    <FontAwesomeIcon icon={faInstagram} size="2x" className="mr-[20px]" />
+                </Link>
+                <Link href={"https://github.com/CECOM-CAU"}>
+                    <FontAwesomeIcon icon={faGithub} size="2x" className="mr-[20px]" />
+                </Link>
+            </div>
+            <div className="flex flex-row items-end">
+                <div className="font-gmarket-b text-[20px]">Contact</div><div className="font-gmarket-m text-[20px] ml-[10px]">cecom.cau@gmail.com</div>
+            </div>
+            <div className="border-[1px] border-[#000000] w-[200px] my-[20px]"></div>
+            <div className="text-[15px] my-[10px]">
+                Designed by Yubin Seo / Developed by Yongmin Yoo, Sooghyun Lim, Serin Jeong
+            </div>
+            <div className="text-[15px] mb-[10px]">
+                &#169; 2024 CECOM ALL RIGHT RESERVED.
+            </div>
+        </div>
+    )
+}
+
+export default FooterMobile;


### PR DESCRIPTION
## Summary
Desktop Footer의 변경사항을 반영하였습니다.
Mobile Footer를 구현하였습니다.

## Description
- 회의 결과에 따라, Desktop Footer의 Designer 및 Developer 문구를 영문으로 변경하였습니다.
- Instagram 및 GitHub 바로가기에 Link 속성을 적용하였습니다.
- 반응형 조건을 적용하여 Mobile Footer가 Desktop 대신 렌더링되도록 하였습니다. 다만, Desktop Footer를 그대로 이용하여도 별 문제 없을 것 같으나, 현재 전체 레이아웃이 Mobile View에서 고장나는 관계로 정확한 사항 확인이 어려워 일단 조건분기를 추가해두었습니다. 추후 각 Page의 Mobile 구현이 완료된 뒤, Desktop Footer 만으로도 문제가 없다면 조건문 제거를 진행하면 될 것 같습니다.