### PR TITLE
[FIX] BE Members API 누락사항 수정

### DIFF
--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -139,7 +139,7 @@ export const getAdminList = async () => {
                 role: memberDoc.role
             });
         }
-        adminList.push({list: adminItemList, year: adminDoc.get("year")});
+        adminList.push({list: adminItemList, year: Number(adminDoc.id)});
     }
 
     return adminList;


### PR DESCRIPTION
## Summary
Back-End Members API의 누락된 데이터를 수정하였습니다.

## Description
- Members API의 `year` 데이터가 누락되는 문제를 해결하였습니다.
- DB에서 `year` 데이터를 Firestore Document ID 값으로 지정해놓고, `docs.get("year")`로 내부속성 처럼 접근해버린 바보이슈..였습니다.