### PR TITLE
[DEV] members page card 수정 및 모바일 구현

### DIFF
--- a/src/app/members/_components/Backcard.tsx
+++ b/src/app/members/_components/Backcard.tsx
@@ -11,11 +11,14 @@ const InstaButton = ({role,member}:AdminItem) => {
         setIsClicked(!isClicked);
     }
     return(
-        <div onClick={() => HandlePj}>
-            <Link href={member.instagram}>
-                <FontAwesomeIcon icon={faInstagram} size="xl" className="ml-[-9px]"/>
-            </Link>
+        <div className={`${member.instagram.length > 0 ? "visible" : "invisible"}`}>
+            <div onClick={() => HandlePj}>
+                <Link href={'https://www.instagram.com/'+member.instagram}>
+                    <FontAwesomeIcon icon={faInstagram} size="xl"/>
+                </Link>
+            </div>
         </div>
+
     );
 }
 const GitButton = ({role,member}:AdminItem) => {
@@ -24,11 +27,14 @@ const GitButton = ({role,member}:AdminItem) => {
         setIsClicked(!isClicked);
     }
     return(
-        <div onClick={() => HandlePj}>
-            <Link href={member.github}>
-                <FontAwesomeIcon icon={faGithub} size="xl" className="ml-[-9px]"/>
-            </Link>
+        <div className={`${member.github.length > 0 ? "visible" : "invisible"}`}>
+            <div onClick={() => HandlePj}>
+                <Link href={'https://www.github.com/'+member.github}>
+                    <FontAwesomeIcon icon={faGithub} size="xl"/>
+                </Link>
+            </div>
         </div>
+
     );
 }
 const MemberBackCard = ({member,role}:AdminItem) => {
@@ -36,17 +42,16 @@ const MemberBackCard = ({member,role}:AdminItem) => {
         <div className={'pt-[40px] pl-[20px] w-[260px] h-[400px] mr-[20px] mb-[20px] border-0 rounded-lg shadow-xl'}>
             <div className={'flex flex-col'}>
                 <img className={'w-[63px] h-[69px]'} src="/MemberBack.jpg" alt="BackIcon"/>
-                <div className={'flex flex-col mt-[8px]'}>
-                    <div className={'h-[28px] w-[140px] grid grid-cols-5 grid-rows-1 items-end'}>
-                        <span className={'col-span-3 text-[24px] h-[28px] font-gmarket-m mr-[5px]'}>{member.name}</span>
+                <div className={'flex flex-col mt-[14px]'}>
+                    <div className={'h-[24px] w-[140px] flex flex-row gap-[5px] items-center'}>
+                        <span className={'pt-[3px] text-[24px] place-self-center font-gmarket-m mr-[5px]'}>{member.name}</span>
                         <InstaButton member={member} role={role}/>
                         <GitButton member={member} role={role}/>
                     </div>
-                    <div className={'mt-[8px] flex flex-col'}>
+                    <div className={'mt-[4px] flex flex-col'}>
                         <div className={'flex flex-row items-center'}>
-                            <span className={'text-[15px] font-gmarket-m'}>{member.name}</span>
-                            <div className={'mr-[7px] ml-[7px] border border-left border-s-gray-400 h-[15px]'}></div>
-                            <span className={'text-[15px] font-gmarket'}>{role}</span>
+                            <div className={'mr-[7px] ml-[1px] border border-left border-s-gray-400 h-[15px]'}></div>
+                            <span className={'mt-[3px] text-[15px] font-gmarket'}>{role}</span>
                         </div>
                         <span className={'font-gmarket text-[15px]'}>{member.department}</span>
                     </div>

--- a/src/app/members/_components/DeskFlip.tsx
+++ b/src/app/members/_components/DeskFlip.tsx
@@ -5,7 +5,7 @@ import MemberFrontCard from "@/app/members/_components/membercard";
 import MemberBackCard from "@/app/members/_components/Backcard";
 import {AdminItem} from "@/utils/Interfaces";
 
-const MemberCard = ({role,member}:AdminItem) => {
+const DeskMemberCard = ({role,member}:AdminItem) => {
     const [isFlipped, setIsFlipped] = useState(false);
 
     const Handleimage = () => {
@@ -24,4 +24,4 @@ const MemberCard = ({role,member}:AdminItem) => {
     );
 };
 
-export default MemberCard;
+export default DeskMemberCard;

--- a/src/app/members/_components/MobFlip.tsx
+++ b/src/app/members/_components/MobFlip.tsx
@@ -1,0 +1,27 @@
+'use client'
+import {useState} from "react";
+import ReactCardFlip from "react-card-flip";
+import MemberFrontCard from "@/app/members/_components/membercard";
+import MemberBackCard from "@/app/members/_components/Backcard";
+import {AdminItem} from "@/utils/Interfaces";
+
+const MobMemberCard = ({role,member}:AdminItem) => {
+    const [isFlipped, setIsFlipped] = useState(false);
+
+    const Handleimage = () => {
+        setIsFlipped(!isFlipped);
+    };
+
+    return (
+        <ReactCardFlip isFlipped={isFlipped} flipDirection={"horizontal"}>
+            <div onMouseEnter={Handleimage}>
+                <MemberFrontCard member={member} role={role}/>
+            </div>
+            <div onMouseEnter={Handleimage}>
+                <MemberBackCard member={member} role={role}/>
+            </div>
+        </ReactCardFlip>
+    );
+};
+
+export default MobMemberCard;

--- a/src/app/members/_components/projectname.tsx
+++ b/src/app/members/_components/projectname.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import {useState} from "react";
 import {Admin, AdminItem} from "@/utils/Interfaces";
+import {id} from "postcss-selector-parser";
 
 interface props {
     link : string;
@@ -12,7 +13,7 @@ const Projectname = ({role,member}:AdminItem) => {
     }
     return(
         <div onClick={() => HandlePj}>
-            <Link href="">
+            <Link href={`/activities/${id}`}>
                 <div className={'h-[20px] flex flex-col justify-center item-center' +
                     'bg-cover rounded-2xl border-0 bg-gray-300'}>
                     <span className={'text-[11px] mx-[3px] place-self-center font-gmarket'}>{member.project}</span>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,13 +1,17 @@
 'use client'
 import PageTitle from "@/app/_components/PageTitle";
-import MemberCard from "@/app/members/_components/flip";
+import MemberCard from "@/app/members/_components/DeskFlip";
 import {AdminList} from "@/utils/DummyData";
 import {Admin, AdminItem} from "@/utils/Interfaces";
 import {useEffect, useState} from "react";
 import axios from "axios";
+import MenuBTN from "@/app/activities/_components/MenuBTN";
+import DeskMemberCard from "@/app/members/_components/DeskFlip";
+import MobMemberCard from "@/app/members/_components/MobFlip";
 
 const MembersPage = () => {
     const [adminList, setAdminList] = useState<Admin[]>(AdminList);
+    const [current,setCurrent] = useState(AdminList[0]['year']);
 
     useEffect(() => {
         axios.get('/api/members/getMembersList')
@@ -26,31 +30,44 @@ const MembersPage = () => {
                 <PageTitle>Members</PageTitle>
             </div>
             <div className={'w-full flex flex-col items-center'}>
-                <YearButton/>
-                <span className={'flex flex-row justify-center w-[1200px] flex-wrap'}>
-                    {adminList.map(({list,year}:Admin)=>(
-                        list.map(({member,role}:AdminItem)=>(
-                            <MemberCard member={member} role={role}/>
-                        ))
-                    ))}
-                </span>
+                <NavDesktop current={current} HandleCurrent={setCurrent}/>
+                <div className={'hidden lg:block'}>
+                    <div className={'flex flex-row justify-center w-[1200px] flex-wrap'}>
+                        {adminList.map(({list,year}:Admin)=>(
+                            list.map(({member,role}:AdminItem)=>(
+                                <DeskMemberCard member={member} role={role}/>
+                            ))
+                        ))}
+                    </div>
+                </div>
+                <div className={'block lg:hidden'}>
+                    <div className={'flex flex-col justify-center w-full'}>
+                        {adminList.map(({list,year}:Admin)=>(
+                            list.map(({member,role}:AdminItem)=>(
+                                <MobMemberCard member={member} role={role}/>
+                            ))
+                        ))}
+                    </div>
+                </div>
             </div>
         </div>
     );
 }
 
-const YearButton = () => {
-    return (
-        <div className="mr-[20px] mb-[25px] grid w-[70px] h-[30px]">
-                <select color={'transparent'} className="font-gmarket-m text-[16px] border-0 rounded-xl row-start-1 col-start-1 bg-gray-200">
-                        {AdminList.map(({list,year}:Admin)=>(
-                            <option value='year' className="border-0 font-gmarket-l">{year}</option>
-                        ))}
-                </select>
-        </div>
-    );
+interface Props{
+    current: number;
+    HandleCurrent: (num:number)=>void;
 }
-const style = () => {
+const NavDesktop=({current,HandleCurrent}:Props)=>{
+    return(
+        <nav className="w-full gap-x-[40px] flex flex-row justify-center h-50">
+            {AdminList.map(({list,year}:Admin)=>(
+                <div onClick={() => HandleCurrent(year)}>
+                    <MenuBTN isClicked={year===current}>{year}</MenuBTN>
+                </div>
+            ))}
+        </nav>
+    )
 }
 
 export default MembersPage;


### PR DESCRIPTION
## Summary
멤버 페이지의 카드를 수정하였습니다.

## Description
- member 이름과 아이콘들의 위치를 맞추었습니다.
- members 인스타 깃헙의 링크를 추가하고, 계정이 없다면 아이콘이 뜨지 않도록 하였습니다.
- members의 year를 select바에서 navbar로 바꾸었습니다.
- member 뒷 카드의 프로젝트를 클릭하면 액티비티 상세 페이지로 넘어가도록 하였습니다.
- 새 파일(MobFlip)을 추가해 member 카드의 모바일버전을 만들었습니다. 이 과정에서 기존 파일 flip을 DeskFlip으로 이름 변경하였습니다.
- 나눠서 커밋했어야 했는데 그러지 못했네요,,,앞으로는 꼭 자주 커밋하겠습니다..,,