### PR TITLE
[FIX] BE Activity Photo 관련 카운팅 문제

### DIFF
--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -84,7 +84,7 @@ const getActivityPhotos = async (activityID: string, photoCnt: number) => {
     for(let photoIdx = 1; photoIdx <= photoCnt; photoIdx++){
         const photoItem = await getActivityPhoto(activityID, photoIdx);
         if(photoItem !== undefined){
-            photoCnt++;
+            photoData.count++;
             photoData.data.push(photoItem);
         }
     }


### PR DESCRIPTION
## Summary
Activity Photo 관련 이슈를 해결하였습니다.

## Description
- Activity Photo API에서 항목 수가 항상 0으로 나오는 문제를 해결하였습니다.