### PR TITLE
[DEV] members 페이지 year bar 수정 및 모바일 select bar 구현 

### DIFF
--- a/src/app/members/_components/Backcard.tsx
+++ b/src/app/members/_components/Backcard.tsx
@@ -39,12 +39,12 @@ const GitButton = ({role,member}:AdminItem) => {
 }
 const MemberBackCard = ({member,role}:AdminItem) => {
     return (
-        <div className={'pt-[40px] pl-[20px] w-[260px] h-[400px] mr-[20px] mb-[20px] border-0 rounded-lg shadow-xl'}>
+        <div className={'pt-[40px] pl-[20px] w-[260px] h-[400px] border-0 rounded-lg shadow-xl'}>
             <div className={'flex flex-col'}>
                 <img className={'w-[63px] h-[69px]'} src="/MemberBack.jpg" alt="BackIcon"/>
                 <div className={'flex flex-col mt-[14px]'}>
                     <div className={'h-[24px] w-[140px] flex flex-row gap-[5px] items-center'}>
-                        <span className={'pt-[3px] text-[24px] place-self-center font-gmarket-m mr-[5px]'}>{member.name}</span>
+                        <span className={'text-[26px] place-self-center font-gmarket-m mr-[5px]'}>{member.name}</span>
                         <InstaButton member={member} role={role}/>
                         <GitButton member={member} role={role}/>
                     </div>

--- a/src/app/members/_components/membercard.tsx
+++ b/src/app/members/_components/membercard.tsx
@@ -3,7 +3,7 @@ import {AdminItem} from "@/utils/Interfaces";
 const MemberFrontCard = ({role,member}:AdminItem) => {
     return(
         <div className={'w-[260px] h-[400px] px-[12px] pt-[12px] ' +
-            'shadow-xl mr-[20px] mb-[20px] border-0 rounded-lg flex flex-col justify-start flex-grow-0 item-center'}>
+            'shadow-xl border-0 rounded-lg flex flex-col justify-start flex-grow-0 item-center'}>
             <img className="w-[260px] h-[260px] flex-grow-0" src="/Memberimg.jpg" alt="Icon"/>
             <div className={'w-[260px] flex flex-row justify-center'}>
                 <div className={'w-[260px] flex flex-col mt-[15px] mb-[15px]'}>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -8,6 +8,7 @@ import axios from "axios";
 import MenuBTN from "@/app/activities/_components/MenuBTN";
 import DeskMemberCard from "@/app/members/_components/DeskFlip";
 import MobMemberCard from "@/app/members/_components/MobFlip";
+import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 
 const MembersPage = () => {
     const [adminList, setAdminList] = useState<Admin[]>(AdminList);
@@ -26,26 +27,36 @@ const MembersPage = () => {
 
     return (
         <div className={'w-full flex flex-col'}>
-            <div className={'w-full'}>
+            <div className={'hidden lg:block'}>
                 <PageTitle>Members</PageTitle>
             </div>
+            <div className={'block lg:hidden'}>
+                <MobilePageTitle>Members</MobilePageTitle>
+            </div>
             <div className={'w-full flex flex-col items-center'}>
-                <NavDesktop current={current} HandleCurrent={setCurrent}/>
                 <div className={'hidden lg:block'}>
-                    <div className={'flex flex-row justify-center w-[1200px] flex-wrap'}>
+                    <NavDesktop current={current} HandleCurrent={setCurrent}/>
+                </div>
+                <div className={'block lg:hidden'}>
+                    <select value={current} onChange={(item)=>setCurrent(Number(item.target.value))}
+                            className={'ml-[-10px] pl-[3px] mb-[15px] text-[16px] font-gmarket-m ' +
+                                'w-[75px] h-[33px] bg-gray-200 rounded-xl'}>
                         {adminList.map(({list,year}:Admin)=>(
-                            list.map(({member,role}:AdminItem)=>(
-                                <DeskMemberCard member={member} role={role}/>
-                            ))
+                                <option value={year}>{year}</option>
+                        ))}
+                    </select>
+                </div>
+                <div className={'hidden lg:block'}>
+                    <div className={'flex flex-row gap-[20px] justify-center w-[1200px] flex-wrap'}>
+                        {adminList[AdminList[0]['year']-current].list.map(({member,role}:AdminItem)=>(
+                            <DeskMemberCard member={member} role={role}/>
                         ))}
                     </div>
                 </div>
                 <div className={'block lg:hidden'}>
-                    <div className={'flex flex-col justify-center w-full'}>
-                        {adminList.map(({list,year}:Admin)=>(
-                            list.map(({member,role}:AdminItem)=>(
-                                <MobMemberCard member={member} role={role}/>
-                            ))
+                    <div className={'flex flex-col gap-[20px] justify-center w-full'}>
+                        {adminList[AdminList[0]['year']-current].list.map(({member,role}:AdminItem)=>(
+                            <MobMemberCard member={member} role={role}/>
                         ))}
                     </div>
                 </div>
@@ -60,14 +71,15 @@ interface Props{
 }
 const NavDesktop=({current,HandleCurrent}:Props)=>{
     return(
-        <nav className="w-full gap-x-[40px] flex flex-row justify-center h-50">
+        <nav className="w-full mb-[15px] gap-x-[40px] flex flex-row justify-center h-50">
             {AdminList.map(({list,year}:Admin)=>(
                 <div onClick={() => HandleCurrent(year)}>
                     <MenuBTN isClicked={year===current}>{year}</MenuBTN>
                 </div>
             ))}
         </nav>
-    )
+    );
 }
+
 
 export default MembersPage;


### PR DESCRIPTION
## Summary
members 페이지의 year bar를 수정하고 모바일 버전의 select bar를 구현했습니다.

## Description
- navbar에서 연도를 클릭하면 그 연도에 따른 카드가 나오도록 하였습니다.
- 모바일 버전에서는 드롭다운(select bar)가 나오도록, 마찬가지로 select되면 연도에 따른 카드가 나오도록 하였습니다.
- 모바일 버전의 제목을 mobilepagetitle로 바꾸었습니다.
