### PR TITLE
[FIX] members 페이지 card flip 수정

### DIFF
--- a/src/app/members/_components/Backcard.tsx
+++ b/src/app/members/_components/Backcard.tsx
@@ -39,7 +39,7 @@ const GitButton = ({role,member}:AdminItem) => {
 }
 const MemberBackCard = ({member,role}:AdminItem) => {
     return (
-        <div className={'pt-[40px] pl-[20px] w-[260px] h-[400px] border-0 rounded-lg shadow-xl'}>
+        <div className={'pt-[40px] pl-[20px] w-[260px] h-[400px] bg-white border-0 rounded-lg shadow-xl'}>
             <div className={'flex flex-col'}>
                 <img className={'w-[63px] h-[69px]'} src="/MemberBack.jpg" alt="BackIcon"/>
                 <div className={'flex flex-col mt-[14px]'}>

--- a/src/app/members/_components/DeskFlip.tsx
+++ b/src/app/members/_components/DeskFlip.tsx
@@ -13,14 +13,16 @@ const DeskMemberCard = ({role,member}:AdminItem) => {
     };
 
     return (
-      <ReactCardFlip isFlipped={isFlipped} flipDirection={"horizontal"}>
-          <div onMouseEnter={Handleimage}>
-              <MemberFrontCard member={member} role={role}/>
-          </div>
-          <div onMouseLeave={Handleimage}>
-              <MemberBackCard member={member} role={role}/>
-          </div>
-      </ReactCardFlip>
+        <div className="group [perspective:1000px]">
+            <div className="transition-all duration-500 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]">
+                <div className="">
+                    <MemberFrontCard member={member} role={role}/>
+                </div>
+                <div className="absolute inset-0 [transform:rotateY(180deg)] [backface-visibility:hidden]">
+                    <MemberBackCard member={member} role={role}/>
+                </div>
+            </div>
+        </div>
     );
 };
 


### PR DESCRIPTION
## Summary
members 페이지에 card flip을 수정하였습니다.

## Description
- npm install react-card-flip으로 하는 방식은 마우스를 떼도 카드가 원래대로 안돌아가는 오류가 가끔 있어서 activity 카드가 flip되는 방식대로 수정하였습니다.
- 모바일 버전의 카드는 호버가 아니라 클릭으로 작동해서 오류가 없는거같아 원래대로 두었습니다.
