### PR TITLE
[FIX] Fetching Cache 비활성화 설정 적용

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -5,6 +5,8 @@ import {ActivityContent} from "@/utils/Interfaces";
 import {DesktopDetail} from "@/app/activities/[id]/_component/desktop/DesktopDetail";
 import {MobileDetail} from "@/app/activities/[id]/_component/mobile/MobileDetail";
 
+export const dynamic = "force-dynamic";
+
 const ActivityDetailPage = ({params}: { params: { id: string } }) => {
     const {id} = params;
 

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -7,6 +7,8 @@ import ActivityCard from "@/app/activities/_components/ActivityCard";
 import axios from "axios";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 
+export const dynamic = "force-dynamic";
+
 const ActivitiesPage = () => {
     const [all, setAll] = useState<boolean>(true);
     const [project, setProject] = useState<boolean>(false);

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -8,6 +8,8 @@ import DeskMemberCard from "@/app/members/_components/DeskFlip";
 import MobMemberCard from "@/app/members/_components/MobFlip";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 
+export const dynamic = "force-dynamic";
+
 const MembersPage = () => {
     const [adminList, setAdminList] = useState<Admin[]>([]);
     const [current,setCurrent] = useState(0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,9 @@ import {DesktopHome} from "@/app/_components/mainPage/desktop/DesktopHome";
 import {MobileHome} from "@/app/_components/mainPage/mobile/MobileHome";
 import {useEffect, useState} from "react";
 import axios from "axios";
+
+export const dynamic = "force-dynamic";
+
 export default function Home() {
     const [project, setProject] = useState<string>('');
     const [mentoring, setMentoring] = useState<string>('');

--- a/src/app/things/page.tsx
+++ b/src/app/things/page.tsx
@@ -8,6 +8,8 @@ import MobSmallbox from "@/app/things/_components/MobileSmallBox";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 import ThingMenu from "@/app/things/_components/ThingMenu";
 
+export const dynamic = "force-dynamic";
+
 const ThingsPage = () => {
     const [All, setAll] = useState<boolean>(true);
     const [Sensors, setSensor] = useState<boolean>(false);


### PR DESCRIPTION
## Summary
API Fetch 과정에서 Cache가 호출되어, 최신 데이터가 반환되지 않는 문제를 해결하였습니다.

## Description
- Axios 호출을 수행하는 각 Page에 `Route Segment Config`을 구성하였습니다.
- `dynamic`의 속성값을 `force-dynamic`으로 지정하여 Cache를 사용하지 않도록 하였습니다.