### PR TITLE
[FIX] Fetching Cache 비활성화 설정 적용

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -5,8 +5,6 @@ import {ActivityContent} from "@/utils/Interfaces";
 import {DesktopDetail} from "@/app/activities/[id]/_component/desktop/DesktopDetail";
 import {MobileDetail} from "@/app/activities/[id]/_component/mobile/MobileDetail";
 
-export const dynamic = "force-dynamic";
-
 const ActivityDetailPage = ({params}: { params: { id: string } }) => {
     const {id} = params;
 

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -7,8 +7,6 @@ import ActivityCard from "@/app/activities/_components/ActivityCard";
 import axios from "axios";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 
-export const dynamic = "force-dynamic";
-
 const ActivitiesPage = () => {
     const [all, setAll] = useState<boolean>(true);
     const [project, setProject] = useState<boolean>(false);

--- a/src/app/api/activities/getActivitiesData/[id]/route.ts
+++ b/src/app/api/activities/getActivitiesData/[id]/route.ts
@@ -3,6 +3,7 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 import {getActivityData} from "@/utils/FirebaseUtil";
 
+export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,

--- a/src/app/api/activities/getActivitiesList/route.ts
+++ b/src/app/api/activities/getActivitiesList/route.ts
@@ -3,6 +3,7 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {getActivityList} from "@/utils/FirebaseUtil";
 import {corsHeader} from "@/utils/CorsUtil";
 
+export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,

--- a/src/app/api/main/getMainImages/route.ts
+++ b/src/app/api/main/getMainImages/route.ts
@@ -3,6 +3,7 @@ import {API_RESULT, MainImage} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 import {getMainImage} from "@/utils/FileUtil";
 
+export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,

--- a/src/app/api/members/getMembersList/route.ts
+++ b/src/app/api/members/getMembersList/route.ts
@@ -3,6 +3,7 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {getAdminList} from "@/utils/FirebaseUtil";
 import {corsHeader} from "@/utils/CorsUtil";
 
+export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,

--- a/src/app/api/things/getThingsList/route.ts
+++ b/src/app/api/things/getThingsList/route.ts
@@ -3,6 +3,7 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {getThingList} from "@/utils/FirebaseUtil";
 import {corsHeader} from "@/utils/CorsUtil";
 
+export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -8,8 +8,6 @@ import DeskMemberCard from "@/app/members/_components/DeskFlip";
 import MobMemberCard from "@/app/members/_components/MobFlip";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 
-export const dynamic = "force-dynamic";
-
 const MembersPage = () => {
     const [adminList, setAdminList] = useState<Admin[]>([]);
     const [current,setCurrent] = useState(0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,6 @@ import {DesktopHome} from "@/app/_components/mainPage/desktop/DesktopHome";
 import {MobileHome} from "@/app/_components/mainPage/mobile/MobileHome";
 import {useEffect, useState} from "react";
 import axios from "axios";
-
-export const dynamic = "force-dynamic";
-
 export default function Home() {
     const [project, setProject] = useState<string>('');
     const [mentoring, setMentoring] = useState<string>('');

--- a/src/app/things/page.tsx
+++ b/src/app/things/page.tsx
@@ -8,8 +8,6 @@ import MobSmallbox from "@/app/things/_components/MobileSmallBox";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
 import ThingMenu from "@/app/things/_components/ThingMenu";
 
-export const dynamic = "force-dynamic";
-
 const ThingsPage = () => {
     const [All, setAll] = useState<boolean>(true);
     const [Sensors, setSensor] = useState<boolean>(false);


### PR DESCRIPTION
## Summary
API Fetch 과정에서 Cache가 호출되어, 최신 데이터가 반환되지 않는 문제를 이번에야말로 진짜로 해결하였습니다.

## Description
- 기존 #149 에서 작업한 내용은, FE측의 Axios 호출부에서 `Dynamic Render`를 활성화 하였습니다.
- 그러나 실제로 Cache가 문제를 유발한 부분은 FE가 아닌 BE의 Route Handler 부분으로, 해당 부분에 `Dynamic Render`를 적용하였습니다.
- 기존 #149 에서 작업한 내용은 `revert` 하였습니다.