### PR TITLE
[DEV] Recruit API 구현

### DIFF
--- a/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
         RESULT_DATA: undefined
     }
 
-    const submissionDetail = await getRecruitSubmissionDetail();
+    const submissionDetail = await getRecruitSubmissionDetail(params.id);
     if(submissionDetail === undefined || submissionDetail.id == 0){
         apiResult.RESULT_CODE = 100;
         apiResult.RESULT_MSG = "An Error Occurred";

--- a/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
@@ -11,7 +11,7 @@ export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
     }
 
     const submissionDetail = await getRecruitSubmissionDetail(params.id);
-    if(submissionDetail === undefined || submissionDetail.id == 0){
+    if(submissionDetail === undefined || submissionDetail.timestamp == 0){
         apiResult.RESULT_CODE = 100;
         apiResult.RESULT_MSG = "An Error Occurred";
         apiResult.RESULT_DATA = undefined;

--- a/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
@@ -3,7 +3,7 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 import {getRecruitSubmissionDetail} from "@/utils/FirebaseUtil";
 
-export async function GET(_: NextRequest) {
+export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
         RESULT_MSG: "Success",

--- a/src/app/api/recruit/getSubmissionDetail/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
+import {getRecruitSubmissionDetail} from "@/utils/FirebaseUtil";
 
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
@@ -8,6 +9,16 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    const submissionDetail = await getRecruitSubmissionDetail();
+    if(submissionDetail === undefined || submissionDetail.id == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
+
+    apiResult.RESULT_DATA = submissionDetail;
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getSubmissionDetail/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/route.ts
@@ -1,0 +1,13 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+import {corsHeader} from "@/utils/CorsUtil";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
+import {getAdminList, getRecruitSubmissionList} from "@/utils/FirebaseUtil";
 
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
@@ -8,6 +9,16 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    const submissionList = await getRecruitSubmissionList();
+    if(submissionList === undefined || submissionList.data.length == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
+
+    apiResult.RESULT_DATA = submissionList;
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -1,0 +1,13 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+import {corsHeader} from "@/utils/CorsUtil";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -2,7 +2,7 @@ import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 
-export async function GET(_: NextRequest) {
+export async function POST(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
         RESULT_MSG: "Success",

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT, RecruitSubmissionDetail} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
+import {postRecruitingSubmission} from "@/utils/FirebaseUtil";
 
 export async function POST(req: NextRequest) {
     const apiResult: API_RESULT = {
@@ -15,6 +16,13 @@ export async function POST(req: NextRequest) {
         id: submissionBody.id,
         name: submissionBody.name,
         timestamp: 0
+    }
+
+    const submissionResult = await postRecruitingSubmission(submissionData);
+    if(!submissionResult){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
     }
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
     }
 
     const submissionResult = await postRecruitingSubmission(submissionData);
-    if(!submissionResult){
+    if(submissionResult == 0){
         apiResult.RESULT_CODE = 100;
         apiResult.RESULT_MSG = "An Error Occurred";
         apiResult.RESULT_DATA = undefined;

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -1,0 +1,13 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+import {corsHeader} from "@/utils/CorsUtil";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -1,12 +1,20 @@
 import {NextRequest, NextResponse} from "next/server";
-import {API_RESULT} from "@/utils/Interfaces";
+import {API_RESULT, RecruitSubmissionDetail} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 
-export async function POST(_: NextRequest) {
+export async function POST(req: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
+    }
+
+    const submissionBody: RecruitSubmissionDetail = JSON.parse(await req.text());
+    const submissionData: RecruitSubmissionDetail = {
+        department: submissionBody.department,
+        id: submissionBody.id,
+        name: submissionBody.name,
+        timestamp: 0
     }
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });

--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -25,5 +25,8 @@ export async function POST(req: NextRequest) {
         apiResult.RESULT_DATA = undefined;
     }
 
+    submissionData.timestamp = submissionResult;
+    apiResult.RESULT_DATA = submissionData;
+
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -8,7 +8,7 @@ import {
     ActivityItem,
     Admin,
     AdminItem,
-    Member,
+    Member, RecruitSubmissionList,
     Thing,
     ThingItem
 } from "@/utils/Interfaces";
@@ -155,6 +155,15 @@ export const getAdminList = async () => {
     }
 
     return adminList;
+}
+
+export const getRecruitSubmissionList = async () => {
+    const submissionList: RecruitSubmissionList = {
+        count: 0,
+        data: []
+    }
+
+    return submissionList;
 }
 
 export const getThingList = async () => {

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -158,6 +158,8 @@ export const getAdminList = async () => {
 }
 
 export const getRecruitSubmissionDetail = async (studentID: string) => {
+    initFirebase();
+
     const submissionDetail: RecruitSubmissionDetail = {
         department: "",
         id: "",

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -251,3 +251,7 @@ export const getThingList = async () => {
 
     return thingList;
 }
+
+export const postRecruitingSubmission = (submission: RecruitSubmissionDetail) => {
+    return true;
+}

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -8,7 +8,7 @@ import {
     ActivityItem,
     Admin,
     AdminItem,
-    Member, RecruitSubmissionList,
+    Member, RecruitSubmissionItem, RecruitSubmissionList,
     Thing,
     ThingItem
 } from "@/utils/Interfaces";
@@ -158,9 +158,33 @@ export const getAdminList = async () => {
 }
 
 export const getRecruitSubmissionList = async () => {
+    initFirebase();
+
     const submissionList: RecruitSubmissionList = {
         count: 0,
         data: []
+    }
+
+    const recruitSubmissionDocs = await getDocs(collection(firestoreDB!, "Recruit"));
+    if(recruitSubmissionDocs.empty){
+        return submissionList;
+    }
+
+    for(const recruitSubmissionDoc of recruitSubmissionDocs.docs){
+        const submissionItem: RecruitSubmissionItem = {
+            department: recruitSubmissionDoc.get("department"),
+            id: recruitSubmissionDoc.get("id"),
+            name: recruitSubmissionDoc.get("name"),
+            timestamp: Number.parseInt(recruitSubmissionDoc.id)
+        }
+
+        if(submissionItem.department !== undefined
+            && submissionItem.id !== undefined
+            && submissionItem.name !== undefined
+            && submissionItem.timestamp !== undefined){
+            submissionList.count++;
+            submissionList.data.push(submissionItem);
+        }
     }
 
     return submissionList;

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -8,7 +8,7 @@ import {
     ActivityItem,
     Admin,
     AdminItem,
-    Member, RecruitSubmissionItem, RecruitSubmissionList,
+    Member, RecruitSubmissionDetail, RecruitSubmissionItem, RecruitSubmissionList,
     Thing,
     ThingItem
 } from "@/utils/Interfaces";
@@ -155,6 +155,17 @@ export const getAdminList = async () => {
     }
 
     return adminList;
+}
+
+export const getRecruitSubmissionDetail = async () => {
+    const submissionDetail: RecruitSubmissionDetail = {
+        department: "",
+        id: 0,
+        name: "",
+        timestamp: 0
+    }
+
+    return submissionDetail;
 }
 
 export const getRecruitSubmissionList = async () => {

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -160,9 +160,25 @@ export const getAdminList = async () => {
 export const getRecruitSubmissionDetail = async (studentID: string) => {
     const submissionDetail: RecruitSubmissionDetail = {
         department: "",
-        id: 0,
+        id: "",
         name: "",
         timestamp: 0
+    }
+
+    const recruitSubmissionDocs = await getDocs(collection(firestoreDB!, "Recruit"));
+    if(recruitSubmissionDocs.empty){
+        return submissionDetail;
+    }
+
+    for(const recruitSubmissionDoc of recruitSubmissionDocs.docs){
+        if(recruitSubmissionDoc.get("id") == studentID){
+            submissionDetail.department = recruitSubmissionDoc.get("department");
+            submissionDetail.id = recruitSubmissionDoc.get("id");
+            submissionDetail.name = recruitSubmissionDoc.get("name");
+            submissionDetail.timestamp = Number.parseInt(recruitSubmissionDoc.id);
+
+            break;
+        }
     }
 
     return submissionDetail;

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -157,7 +157,7 @@ export const getAdminList = async () => {
     return adminList;
 }
 
-export const getRecruitSubmissionDetail = async () => {
+export const getRecruitSubmissionDetail = async (studentID: string) => {
     const submissionDetail: RecruitSubmissionDetail = {
         department: "",
         id: 0,

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -1,5 +1,5 @@
 import {FirebaseApp, initializeApp} from "@firebase/app";
-import {collection, doc, Firestore, getDoc, getFirestore, orderBy, query} from "@firebase/firestore";
+import {collection, doc, Firestore, getDoc, getFirestore} from "@firebase/firestore";
 import dotenv from "dotenv";
 import {
     Activity,

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -1,5 +1,5 @@
 import {FirebaseApp, initializeApp} from "@firebase/app";
-import {collection, doc, Firestore, getDoc, getFirestore} from "@firebase/firestore";
+import {collection, doc, Firestore, getDoc, getFirestore, setDoc} from "@firebase/firestore";
 import dotenv from "dotenv";
 import {
     Activity,
@@ -252,6 +252,12 @@ export const getThingList = async () => {
     return thingList;
 }
 
-export const postRecruitingSubmission = (submission: RecruitSubmissionDetail) => {
-    return true;
+export const postRecruitingSubmission = async (submission: RecruitSubmissionDetail) => {
+    initFirebase();
+
+    let postTimestamp = Date.now();
+    submission.timestamp = postTimestamp;
+    await setDoc(doc(firestoreDB!, "Recruit", postTimestamp.toString()), submission);
+
+    return postTimestamp;
 }

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: Activity | ActivityContent | Array<Admin> | MainImage | Member | Photo | Thing | undefined
+    RESULT_DATA: Activity | ActivityContent | Array<Admin> | MainImage | Member | Photo | RecruitSubmissionDetail | RecruitSubmissionList | Thing | undefined
 }
 
 export interface Activity {

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -82,14 +82,14 @@ export interface Photo {
 export interface RecruitSubmissionDetail {
     department: string
     name: string
-    id: number
-    timestamp: number | undefined
+    id: string
+    timestamp: number
 }
 
 export interface RecruitSubmissionItem {
     department: string
     name: string
-    id: number
+    id: string
     timestamp: number
 }
 

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -79,6 +79,18 @@ export interface Photo {
     filename: string,
 }
 
+export interface RecruitSubmissionItem {
+    department: string
+    name: string
+    id: number
+    timestamp: number
+}
+
+export interface RecruitSubmissionList {
+    coutn: number
+    data: Array<RecruitSubmissionItem>
+}
+
 export interface Thing {
     count: number
     data: Array<ThingItem>

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -94,7 +94,7 @@ export interface RecruitSubmissionItem {
 }
 
 export interface RecruitSubmissionList {
-    coutn: number
+    count: number
     data: Array<RecruitSubmissionItem>
 }
 

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -79,6 +79,13 @@ export interface Photo {
     filename: string,
 }
 
+export interface RecruitSubmissionDetail {
+    department: string
+    name: string
+    id: number
+    timestamp: number | undefined
+}
+
 export interface RecruitSubmissionItem {
     department: string
     name: string


### PR DESCRIPTION
## Summary
Recruit 페이지의 기능을 위한 API를 구현하였습니다.

## Description
- Recruit 페이지의 기능을 위한 API를 구현하였습니다.
- `/api/getSubmissionList` Entry로 접속 시, 제출된 지원서 리스트 중, 일부 데이터만을 리스트 형식으로 담아 반환합니다.
- `/api/getSubmissionDetail/[id]` Entry로 접속 시, 해당 `id`값에 일치하는 지원서의 상세 데이터를 반환합니다.
- `/api/postSubmission` Entry로 접속 시, 지정된 데이터를 가공하여 DB에 저장합니다.
- Detail 및 Post API의 경우, 임시 Interface로 구성하였으며, 추후 지원서 질문내용 확정 시 항목에 맞게 수정이 필요합니다.