### PR TITLE
[FIX] Recruit API 수정사항 반영

### DIFF
--- a/src/app/api/recruit/postSubmission/route.ts
+++ b/src/app/api/recruit/postSubmission/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: NextRequest) {
         || submissionBody.department.length == 0
         || submissionBody.grade.length == 0
         || submissionBody.id.length == 0
+        || !submissionBody.isPrivacyCollectAgree
         || submissionBody.name.length == 0
         || submissionBody.phone.length == 0){
         apiResult.RESULT_CODE = 100;

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -229,6 +229,7 @@ export const getRecruitSubmissionList = async () => {
             department: recruitSubmissionDoc.get("department"),
             grade: recruitSubmissionDoc.get("grade"),
             id: recruitSubmissionDoc.get("id"),
+            isPrivacyCollectAgree: recruitSubmissionDoc.get("isPrivacyCollectAgree"),
             name: recruitSubmissionDoc.get("name"),
             phone: recruitSubmissionDoc.get("phone"),
             timestamp: Number.parseInt(recruitSubmissionDoc.id)

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -179,6 +179,7 @@ export const getRecruitSubmissionDetail = async (studentID: string) => {
         department: "",
         grade: "",
         id: "",
+        isPrivacyCollectAgree: false,
         name: "",
         phone: "",
         timestamp: 0
@@ -197,6 +198,7 @@ export const getRecruitSubmissionDetail = async (studentID: string) => {
             submissionDetail.department = recruitSubmissionDoc.get("department");
             submissionDetail.grade = recruitSubmissionDoc.get("grade");
             submissionDetail.id = recruitSubmissionDoc.get("id");
+            submissionDetail.isPrivacyCollectAgree = recruitSubmissionDoc.get("isPrivacyCollectAgree");
             submissionDetail.name = recruitSubmissionDoc.get("name");
             submissionDetail.phone = recruitSubmissionDoc.get("phone");
             submissionDetail.timestamp = Number.parseInt(recruitSubmissionDoc.id);

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -104,6 +104,7 @@ export interface RecruitSubmissionItem {
     department: string
     grade: string
     id: string
+    isPrivacyCollectAgree: boolean
     name: string
     phone: string
     timestamp: number

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -91,6 +91,7 @@ export interface RecruitSubmissionDetail {
     department: string
     grade: string
     id: string
+    isPrivacyCollectAgree: boolean
     name: string
     phone: string
     timestamp: number


### PR DESCRIPTION
## Summary
Recruit API에 개인정보 수집동의 관련 항목을 추가하였습니다.

## Description
- Recruit API 관련 Interface에 개인정보 수집동의 항목을 `bool` 자료형인 `isPrivacyCollectAgree` 변수로 추가 정의하였습니다.
- `/api/recruit/postSubmission` 호출 시, `isPrivacyCollectAgree` 항목이 `false`인 경우, 업로드가 진행되지 않도록 하였습니다.
- `/api/recruit/getSubmissionList` 및 `/api/recruit/getSubmissionDetail`의 동작을 변경된 Interface에 맞추어 수정하였습니다.