### PR TITLE
[DEV] Recruit 예외처리 API 연동 구현

### DIFF
--- a/src/app/api/recruit/getAvailibility/route.ts
+++ b/src/app/api/recruit/getAvailibility/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
+import {getRecruitAvailibility} from "@/utils/FirebaseUtil";
 
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
@@ -8,6 +9,9 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    const recruitAvail = await getRecruitAvailibility();
+    apiResult.RESULT_DATA = recruitAvail;
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getAvailibility/route.ts
+++ b/src/app/api/recruit/getAvailibility/route.ts
@@ -1,0 +1,13 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/utils/Interfaces";
+import {corsHeader} from "@/utils/CorsUtil";
+
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/app/recruit/closed/page.tsx
+++ b/src/app/recruit/closed/page.tsx
@@ -1,8 +1,20 @@
+'use client';
+
 import PageTitle from "@/app/_components/PageTitle";
 import {MobilePageTitle} from "@/app/_components/MobilePageTitle";
-import React from "react";
+import React, {useEffect, useState} from "react";
+import axios from "axios";
 
 const ClosedPage = () => {
+    const [closeMessage, setCloseMessage] = useState("")
+
+    useEffect(() => {
+        axios.get(`/api/recruit/getAvailibility`)
+            .then((res) => {
+                setCloseMessage(res.data.RESULT_DATA.message);
+            });
+    });
+
     return (
         <>
             <div className={'hidden lg:block'}>
@@ -13,7 +25,7 @@ const ClosedPage = () => {
             </div>
             <div className='mt-[100px]'>
                 <div className='text-center md:text-2xl text-[20px] font-bold'>
-                    신입부원 모집기간이 아닙니다.
+                    {closeMessage}
                 </div>
             </div>
         </>

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -13,7 +13,7 @@ import LongAnswer from "@/app/recruit/_components/LongAnswer";
 import axios from "axios";
 import SubmitSuccess from "@/app/recruit/_components/SubmitSuccess";
 import SubmitFailModal from "@/app/recruit/_components/SubmitFailModal";
-import {RecruitSubmissionItem} from "@/utils/Interfaces";
+import {RecruitAvailability, RecruitSubmissionItem} from "@/utils/Interfaces";
 import PersonalInfoConsent from "@/app/recruit/_components/PersonalInfoConsent";
 
 const RecruitPage = () => {
@@ -65,6 +65,16 @@ const RecruitPage = () => {
     for (let year = startYear; year <= endYear; year++) {
         yearArray.push({label: String(year), value: String(year)});
     }
+
+    useEffect(() => {
+        axios.get(`/api/recruit/getAvailibility`)
+            .then((res) => {
+                if(!res.data.RESULT_DATA.isAvail) {
+                    console.log(res.data.RESULT_DATA.isAvail);
+                    console.log(res.data.RESULT_DATA.message);
+                }
+        });
+    });
 
     useEffect(() => {
         window.scrollTo(0, 0);

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faCircleLeft, faCircleRight} from "@fortawesome/free-solid-svg-icons";
 import ChatBubbleQ from "@/app/recruit/_components/ChatBubbleQ";
 import ChatBubbleA from "@/app/recruit/_components/ChatBubbleA";
 import React, {useEffect, useState} from "react";
@@ -85,8 +83,7 @@ const RecruitPage = () => {
                     setQuestionList(res.data.RESULT_DATA.list);
                     setLongAnswer(new Array(res.data.RESULT_DATA.count).fill(''));
                 }
-            ).catch((err) => {
-        })
+            )
     }, []);
 
     useEffect(() => {
@@ -164,9 +161,9 @@ const RecruitPage = () => {
             isPrivacyCollectAgree: personalInfoConsentChecked
 
         }
-        axios.post(`/api/recruit/postSubmission`, applicationData).then((res) => {
+        axios.post(`/api/recruit/postSubmission`, applicationData).then((_) => {
             setSubmitSuccess('success');
-        }).catch((err) => {
+        }).catch((_) => {
             setSubmitSuccess('fail');
         })
     }

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -13,7 +13,7 @@ import LongAnswer from "@/app/recruit/_components/LongAnswer";
 import axios from "axios";
 import SubmitSuccess from "@/app/recruit/_components/SubmitSuccess";
 import SubmitFailModal from "@/app/recruit/_components/SubmitFailModal";
-import {RecruitAvailability, RecruitSubmissionItem} from "@/utils/Interfaces";
+import {RecruitSubmissionItem} from "@/utils/Interfaces";
 import PersonalInfoConsent from "@/app/recruit/_components/PersonalInfoConsent";
 
 const RecruitPage = () => {
@@ -70,8 +70,7 @@ const RecruitPage = () => {
         axios.get(`/api/recruit/getAvailibility`)
             .then((res) => {
                 if(!res.data.RESULT_DATA.isAvail) {
-                    console.log(res.data.RESULT_DATA.isAvail);
-                    console.log(res.data.RESULT_DATA.message);
+                    window.location.replace(`/recruit/closed`);
                 }
         });
     });

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -8,7 +8,12 @@ import {
     ActivityItem,
     Admin,
     AdminItem,
-    Member, RecruitQuestionList, RecruitSubmissionDetail, RecruitSubmissionItem, RecruitSubmissionList,
+    Member,
+    RecruitAvailability,
+    RecruitQuestionList,
+    RecruitSubmissionDetail,
+    RecruitSubmissionItem,
+    RecruitSubmissionList,
     Thing,
     ThingItem
 } from "@/utils/Interfaces";
@@ -155,6 +160,15 @@ export const getAdminList = async () => {
     }
 
     return adminList;
+}
+
+export const getRecruitAvailibility = () => {
+    const recruitAvail: RecruitAvailability = {
+        isAvail: false,
+        message: "Test Message"
+    };
+
+    return recruitAvail;
 }
 
 export const getRecruitQuestionList = async () => {

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -162,10 +162,13 @@ export const getAdminList = async () => {
     return adminList;
 }
 
-export const getRecruitAvailibility = () => {
+export const getRecruitAvailibility = async () => {
+    initFirebase();
+
+    const recruitAvailDoc = await getDoc(doc(firestoreDB!, "RecruitAvailibility", "availibility"));
     const recruitAvail: RecruitAvailability = {
-        isAvail: false,
-        message: "Test Message"
+        isAvail: recruitAvailDoc.get("isAvail"),
+        message: recruitAvailDoc.get("message"),
     };
 
     return recruitAvail;

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: Activity | ActivityContent | Array<Admin> | MainImage | Member | Photo | RecruitQuestionList | RecruitSubmissionDetail | RecruitSubmissionList | Thing | undefined
+    RESULT_DATA: Activity | ActivityContent | Array<Admin> | MainImage | Member | Photo | RecruitAvailability | RecruitQuestionList | RecruitSubmissionDetail | RecruitSubmissionList | Thing | undefined
 }
 
 export interface Activity {

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -79,6 +79,11 @@ export interface Photo {
     filename: string,
 }
 
+export interface RecruitAvailability {
+    isAvail: boolean
+    message: string
+}
+
 export interface RecruitQuestionList {
     count: number
     list: Array<string>


### PR DESCRIPTION
## Summary
Recruit 페이지로 진입하는 경우에 대한 예외처리 API를 구현하고 연동하였습니다.

## Description
- Recruit 페이지 진입을 활성화할지에 대한 T/F 값을 반환하는 API를 `/api/recruit/getAvailibility`에 구현하였습니다.
- Recruit 페이지 진입 시, 해당 API를 통해 T/F 값을 확인하고, `/recruit/closed` 페이지로 리디렉션되도록 합니다.
- Recruit Closed 페이지의 메시지를 API에서 받아오도록 변경하였습니다. 추후 성능개선이 필요합니다.