### PR TITLE
[FIX] Recruit 진입제한 Caching 설정 변경

### DIFF
--- a/src/app/api/recruit/getAvailibility/route.ts
+++ b/src/app/api/recruit/getAvailibility/route.ts
@@ -12,8 +12,7 @@ export async function GET(_: NextRequest) {
         RESULT_DATA: undefined
     }
 
-    const recruitAvail = await getRecruitAvailibility();
-    apiResult.RESULT_DATA = recruitAvail;
+    apiResult.RESULT_DATA = await getRecruitAvailibility();
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getAvailibility/route.ts
+++ b/src/app/api/recruit/getAvailibility/route.ts
@@ -3,6 +3,8 @@ import {API_RESULT} from "@/utils/Interfaces";
 import {corsHeader} from "@/utils/CorsUtil";
 import {getRecruitAvailibility} from "@/utils/FirebaseUtil";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(_: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,


### PR DESCRIPTION
## Summary
Recruit 페이지로의 진입을 제한하는 API의 Caching 설정을 변경하였습니다.

## Description
- Firestore의 값이 Caching되어 올바르게 동작하지 않는 문제를 해결하고자 `export const dynamic = "force-dynamic";` 속성을 `/api/recruit/getAvailibility` API에 적용하였습니다.