### PR TITLE
[FIX] Recruit 한글 중복 이슈 해결

### DIFF
--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -250,7 +250,7 @@ const RecruitPage = () => {
                                                         className="w-full h-[25px] bg-[#ffffff] text-[#000000] focus:outline-none resize-none "
                                                         placeholder="답장 보내기..." value={singleAns}
                                                         onChange={handleInput}
-                                                        onKeyDown={(e) => activeEnter(e)}
+                                                        onKeyUp={(e) => activeEnter(e)}
                                                     ></input>
                                                     <button onClick={handleAns}><img src={'SendBTN.png'}/></button>
 


### PR DESCRIPTION
## Summary
Recruit 페이지에서의 한글 중복 이슈를 해결합니다.

## Description
- MacOS에서 발생하는 한글 중복 이슈를 해결합니다.
- Enter 키 입력의 처리를 기존 `onKeyDown`에서 `onKeyUp`으로 변경하였습니다.