### PR TITLE
[FIX] 모바일 버전 메인 로고 글자 깨짐 해결

### DIFF
--- a/src/app/_components/mainPage/mobile/MobileMainLogo.tsx
+++ b/src/app/_components/mainPage/mobile/MobileMainLogo.tsx
@@ -1,21 +1,21 @@
 const MobileMainLogo = () => {
-    const Main = "font-gmarket-m text-[100px] w-[292px] h-[100px]";
+    const Main = "font-gmarket-m text-[100px] w-[300px] h-[100px]";
     const subBold = "font-gmarket-m text-[22px]";
     const subThin = "font-gmarket-l text-[22px]";
     return (
         <div className="flex flex-col h-[100vh] w-full justify-center items-center">
-            <div className="pt-[-100px]">
+            <div className="flex flex-col pt-[-100px]">
                 <div className={Main}>
-                    CE &#8213;
+                    CE &#8212;
                 </div>
                 <div className={Main}>COM</div>
-                <div className="flex flex-row mt-[30px] justify-start w-[270px] ml-[10px]">
+                <div className="flex flex-row mt-[30px] justify-start w-[300px] ml-[10px]">
                     <div className={subBold}>허상</div>
                     <div className={subThin}>이</div>
                     <div className={subBold}>&nbsp;&#8212;&#8212;&#8212;&#8212;&nbsp;&nbsp;현실</div>
                     <div className={subThin}>이 되는</div>
                 </div>
-                <div className="flex flex-row justify-start w-[270px] mb-[80px] ml-[10px]">
+                <div className="flex flex-row justify-start w-[300px] mb-[80px] ml-[10px]">
                     <div className={subBold}>사소</div>
                     <div className={subThin}>하고</div>
                     <div className={subBold}>&nbsp;위대한&nbsp;&#8212;&#8212;&#8212;&nbsp;생각</div>


### PR DESCRIPTION
## Summary
모바일 버전 메인 로고 글자 깨짐 해결했습니다. 

## Description
- 로고의 width가 부족해서 깨지는 것이라 인식해서 300px로 늘렸습니다. 
- 그리고 ce - 에서 dash가 너무 길어서 비교적 짧은 8213에서 8212로 바꿨습니다.
